### PR TITLE
[WEB-44] JWT토큰 통신 쿠키에서 header/ redirect-uri로 변경

### DIFF
--- a/thanksbucket/src/main/java/com/thanksbucket/security/authentication/www/jwt/JWTAuthenticationFilter.java
+++ b/thanksbucket/src/main/java/com/thanksbucket/security/authentication/www/jwt/JWTAuthenticationFilter.java
@@ -31,12 +31,6 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.debug("JWT Filter PASS START");
         String header = request.getHeader(AUTHORIZATION_HEADER);
-        Cookie cookie = CookieUtils.getCookie(request, AUTHORIZATION_HEADER).orElse(null);
-        //TODO header 없을 때 쿠키로 처리
-        if (header == null && cookie != null) {
-            String token = URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
-            header = token;
-        }
         Authentication unauthenticated = JWTAuthenticationToken.unauthenticated(header);
         try {
             Authentication authResult = this.authenticationManager.authenticate(unauthenticated);

--- a/thanksbucket/src/main/java/com/thanksbucket/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/thanksbucket/src/main/java/com/thanksbucket/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,7 +1,5 @@
 package com.thanksbucket.security.oauth2.handler;
 
-import com.thanksbucket.common.utils.CookieUtils;
-import com.thanksbucket.domain.member.MemberRole;
 import com.thanksbucket.security.authentication.www.jwt.JWTUtils;
 import com.thanksbucket.security.oauth2.CustomOAuth2User;
 import jakarta.servlet.ServletException;
@@ -18,8 +16,8 @@ import java.io.IOException;
 @Slf4j
 @Component
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    public static final String SIGNUP_URL = "/auth/signup";
-    public static final String SIMPLE_URL = "/";
+    public static final String AUTH_SUCCESS_URL = "/auth/success";
+
     private final JWTUtils jwtUtils;
     private final String DEFAULT_REDIRECT_URL; // TODO 추후에 SimpleAuthenticationSuccessHandler 사용하기
     private final Integer JWT_ACCESS_TOKEN_COOKIE_MAX_AGE;
@@ -39,21 +37,13 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
         String jwtToken = jwtUtils.generateToken(customOAuth2User);
         log.info("JWT 토큰 생성: {}", jwtToken);
-        CookieUtils.saveAccessTokenCookie(response, jwtToken, null, JWT_ACCESS_TOKEN_COOKIE_MAX_AGE);
         clearAuthenticationAttributes(request);
-        String redirectURI = getRedirectURI(customOAuth2User);
+        String redirectURI = getRedirectURI(jwtToken);
         getRedirectStrategy().sendRedirect(request, response, redirectURI);
         log.info("OAuth2 로그인 성공 후 리다이렉트 : {}", redirectURI);
     }
 
-    private String getRedirectURI(CustomOAuth2User customOAuth2User) {
-        String redirectURI = DEFAULT_REDIRECT_URL;
-        if (customOAuth2User.getAuthorities().contains(MemberRole.ROLE_GUEST)) {
-            return redirectURI + SIGNUP_URL;
-        }
-        if (customOAuth2User.getAuthorities().contains(MemberRole.ROLE_USER)) {
-            return redirectURI + SIMPLE_URL + customOAuth2User.getNickname();
-        }
-        return redirectURI;
+    private String getRedirectURI(String jwtToken) {
+        return DEFAULT_REDIRECT_URL + AUTH_SUCCESS_URL + "?access_token=Bearer " + jwtToken;
     }
 }

--- a/thanksbucket/src/main/java/com/thanksbucket/ui/api/AuthController.java
+++ b/thanksbucket/src/main/java/com/thanksbucket/ui/api/AuthController.java
@@ -44,9 +44,8 @@ public class AuthController {
         Member member = authService.findById(memberId);
         String jwtToken = jwtUtils.generateToken(member);
         log.debug("회원가입 후 jwtToken: {}", jwtToken);
-        ResponseCookie cookie = CookieUtils.createAccessTokenCookie(jwtToken, null, JWT_ACCESS_TOKEN_COOKIE_MAX_AGE);
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken)
                 .build();
     }
 


### PR DESCRIPTION
jwt 토큰을 쿠키에 저장하지 않습니다.

redirect-url에는 header를 포함할 수 없기에 기존 로직에서 변경합니다.

1. 소셜로그인 성공하면 리다이렉트 : `${REDIRECT_URL}/auth/success?access_token=Bearer ${access_token}` 
    -  여기서  REDIRECT_URL은 프론트 도메인입니다.
2. FE에서 해당 URL을 받으면 LocalStorage에 저장하고 `/auth/profile`로 요청을 보내서 유저의 정보를 요청
3. ROLE에 따라서 로직 수행 (GUEST면 추가 회원가입 `api/auth/signup` , USER면 기본로직)

3-1. `api/auth/signup` 으로 로그인 성공하면 변경됨 Authroization : Bearer ${access_token} 을 헤더로 반환합니다. 이것을 localStorage에 저장하면 됩니다.